### PR TITLE
Add Spotify playlist creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@
 
 This project aims to create an AI-powered system that builds Spotify playlists based on the user's current mood. By analyzing mood inputs and leveraging Spotify's API, it generates music suggestions tailored to how the user feels.
 
+## Running the App
+
+Set the following environment variables so the app can authenticate with Spotify:
+
+```
+SPOTIPY_CLIENT_ID=<your client id>
+SPOTIPY_CLIENT_SECRET=<your client secret>
+SPOTIPY_REDIRECT_URI=<redirect uri configured in the Spotify dashboard>
+OPENAI_API_KEY=<your OpenAI key>
+```
+
+When launched, the app prompts you to authenticate with Spotify and then automatically creates a playlist in your account.
+


### PR DESCRIPTION
## Summary
- integrate Spotify OAuth and playlist creation with spotipy
- implement `create_spotify_playlist` helper
- prompt user to authenticate with Spotify and create playlist after generating
- document environment variables needed for Spotify authentication

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6870e80cef6083328d64bb84a6cef489